### PR TITLE
Build with system shared libary, otherwise use static libstorj

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,10 +3,10 @@
     'target_name': 'libstorj',
     'include_dirs' : [
       '<!(node -e "require(\'nan\')")',
-      '/home/bgf/storj/libstorj-c/release/x86_64-pc-linux-gnu/include'
+      '<!(node ./binding.js include_dirs)'
     ],
     'libraries': [
-      '/home/bgf/storj/libstorj-c/release/x86_64-pc-linux-gnu/lib/libstorj.a',
+      '<!(node ./binding.js libraries)'
     ],
     'sources': [
       'libstorj.cc',
@@ -22,10 +22,8 @@
     'cflags_cc': [
     ],
     'link_settings': {
-      'libraries': [
-      ],
       'ldflags': [
-        '-Wl,--whole-archive /home/bgf/storj/libstorj-c/depends/build/x86_64-pc-linux-gnu/lib/libnettle.a -Wl,--whole-archive /home/bgf/storj/libstorj-c/depends/build/x86_64-pc-linux-gnu/lib/libgnutls.a -Wl,--whole-archive /home/bgf/storj/libstorj-c/depends/build/x86_64-pc-linux-gnu/lib/libhogweed.a -Wl,--whole-archive /home/bgf/storj/libstorj-c/depends/build/x86_64-pc-linux-gnu/lib/libjson-c.a -Wl,--whole-archive /home/bgf/storj/libstorj-c/depends/build/x86_64-pc-linux-gnu/lib/libgmp.a -Wl,--whole-archive /home/bgf/storj/libstorj-c/depends/build/x86_64-pc-linux-gnu/lib/libcurl.a -Wl,--no-whole-archive'
+        '<!(node ./binding.js ldflags)'
       ]
     }
   }]

--- a/binding.gyp
+++ b/binding.gyp
@@ -3,7 +3,10 @@
     'target_name': 'libstorj',
     'include_dirs' : [
       '<!(node -e "require(\'nan\')")',
-      'storj.h',
+      '/home/bgf/storj/libstorj-c/release/x86_64-pc-linux-gnu/include'
+    ],
+    'libraries': [
+      '/home/bgf/storj/libstorj-c/release/x86_64-pc-linux-gnu/lib/libstorj.a',
     ],
     'sources': [
       'libstorj.cc',
@@ -20,9 +23,9 @@
     ],
     'link_settings': {
       'libraries': [
-        '-lstorj'
       ],
       'ldflags': [
+        '-Wl,--whole-archive /home/bgf/storj/libstorj-c/depends/build/x86_64-pc-linux-gnu/lib/libnettle.a -Wl,--whole-archive /home/bgf/storj/libstorj-c/depends/build/x86_64-pc-linux-gnu/lib/libgnutls.a -Wl,--whole-archive /home/bgf/storj/libstorj-c/depends/build/x86_64-pc-linux-gnu/lib/libhogweed.a -Wl,--whole-archive /home/bgf/storj/libstorj-c/depends/build/x86_64-pc-linux-gnu/lib/libjson-c.a -Wl,--whole-archive /home/bgf/storj/libstorj-c/depends/build/x86_64-pc-linux-gnu/lib/libgmp.a -Wl,--whole-archive /home/bgf/storj/libstorj-c/depends/build/x86_64-pc-linux-gnu/lib/libcurl.a -Wl,--no-whole-archive'
       ]
     }
   }]

--- a/binding.js
+++ b/binding.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const { execSync } = require('child_process');
+const stdout = process.stdout;
+const path = require('path');
+const basedir = path.resolve(__dirname);
+
+const libstorjArchive = path.resolve(basedir, './libstorj/lib/libstorj.a');
+const libstorjIncludes = path.resolve(basedir, './libstorj/include');
+
+let archives = [
+  './libstorj/depends/lib/libnettle.a',
+  './libstorj/depends/lib/libgnutls.a',
+  './libstorj/depends/lib/libhogweed.a',
+  './libstorj/depends/lib/libjson-c.a',
+  './libstorj/depends/lib/libgmp.a',
+  './libstorj/depends/lib/libcurl.a'
+];
+
+archives = archives.map((a) => path.resolve(basedir, a));
+
+let installed = true;
+try {
+  execSync('pkg-config --exists libstorj');
+} catch(e) {
+  installed = false;
+}
+
+const cmd = process.argv[2];
+let status = 1;
+
+switch(cmd) {
+  case 'libraries':
+    status = 0;
+    stdout.write(installed ? '-lstorj' : libstorjArchive);
+    break;
+  case 'include_dirs':
+    status = 0;
+    stdout.write(installed ? 'storj.h' : libstorjIncludes);
+    break;
+  case 'ldflags':
+    status = 0;
+    const ldflags = archives.map((a) => '-Wl,--whole-archive ' + a).join(' ');
+    stdout.write(installed ? '' : ldflags + ' -Wl,--no-whole-archive');
+    break;
+  default:
+    status = 1;
+}
+process.exit(status);


### PR DESCRIPTION
This will build with system installed `libstorj.so` if it's available, and then try and use `.a` files otherwise. 

We'll need to have a preinstall script that will download the archive files from the release depending on the system, and if `libstorj.so` isn't available.



