### PR TITLE
Link against downloaded libstorj if not available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules/*
 .idea/*
 storj-test-download.data
 storj-test-upload.data
+libstorj-*

--- a/binding.gyp
+++ b/binding.gyp
@@ -3,7 +3,8 @@
     'target_name': 'libstorj',
     'include_dirs' : [
       '<!(node -e "require(\'nan\')")',
-      '<!(node ./binding.js include_dirs)'
+      '<!(node ./binding.js include_dirs)',
+      '<!(node ./binding.js include_dirs_deps)'
     ],
     'libraries': [
       '<!(node ./binding.js libraries)'

--- a/binding.js
+++ b/binding.js
@@ -4,10 +4,11 @@ const { execSync } = require('child_process');
 const stdout = process.stdout;
 const path = require('path');
 const basedir = path.resolve(__dirname);
-const location = './libstorj-1.1.0-beta';
+const libstorj = require('./package.json').libstorj;
+const basePath = libstorj.basePath;
 
-const libstorjArchive = path.resolve(basedir, location + '/lib/libstorj.a');
-const libstorjIncludes = path.resolve(basedir, location + '/include');
+const libstorjArchive = path.resolve(basedir, basePath + '/lib/libstorj.a');
+const libstorjIncludes = path.resolve(basedir, basePath + '/include');
 
 let archives = [
   '/depends/lib/libnettle.a',
@@ -18,7 +19,7 @@ let archives = [
   '/depends/lib/libcurl.a'
 ];
 
-archives = archives.map((a) => path.resolve(basedir, location + a));
+archives = archives.map((a) => path.resolve(basedir, basePath + a));
 
 let installed = true;
 try {

--- a/binding.js
+++ b/binding.js
@@ -4,20 +4,21 @@ const { execSync } = require('child_process');
 const stdout = process.stdout;
 const path = require('path');
 const basedir = path.resolve(__dirname);
+const location = './libstorj-1.1.0-beta';
 
-const libstorjArchive = path.resolve(basedir, './libstorj/lib/libstorj.a');
-const libstorjIncludes = path.resolve(basedir, './libstorj/include');
+const libstorjArchive = path.resolve(basedir, location + '/lib/libstorj.a');
+const libstorjIncludes = path.resolve(basedir, location + '/include');
 
 let archives = [
-  './libstorj/depends/lib/libnettle.a',
-  './libstorj/depends/lib/libgnutls.a',
-  './libstorj/depends/lib/libhogweed.a',
-  './libstorj/depends/lib/libjson-c.a',
-  './libstorj/depends/lib/libgmp.a',
-  './libstorj/depends/lib/libcurl.a'
+  '/depends/lib/libnettle.a',
+  '/depends/lib/libgnutls.a',
+  '/depends/lib/libhogweed.a',
+  '/depends/lib/libjson-c.a',
+  '/depends/lib/libgmp.a',
+  '/depends/lib/libcurl.a'
 ];
 
-archives = archives.map((a) => path.resolve(basedir, a));
+archives = archives.map((a) => path.resolve(basedir, location + a));
 
 let installed = true;
 try {

--- a/binding.js
+++ b/binding.js
@@ -9,6 +9,7 @@ const basePath = libstorj.basePath;
 
 const libstorjArchive = path.resolve(basedir, basePath + '/lib/libstorj.a');
 const libstorjIncludes = path.resolve(basedir, basePath + '/include');
+const depsIncludes = path.resolve(basedir, basePath + '/depends/include');
 
 let archives = [
   '/depends/lib/libnettle.a',
@@ -39,6 +40,10 @@ switch(cmd) {
   case 'include_dirs':
     status = 0;
     stdout.write(installed ? 'storj.h' : libstorjIncludes);
+    break;
+  case 'include_dirs_deps':
+    status = 0;
+    stdout.write(installed ? '' : depsIncludes);
     break;
   case 'ldflags':
     status = 0;

--- a/download.js
+++ b/download.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const { execSync } = require('child_process');
+const stdout = process.stdout;
+const stderr = process.stderr;
+const path = require('path');
+const basedir = path.resolve(__dirname);
+
+let installed = true;
+try {
+  execSync('pkg-config --exists libstorj');
+} catch(e) {
+  installed = false;
+}
+
+if (installed) {
+  stdout.write(`Skipping download of libstorj, already installed.\n`);
+  process.exit(0);
+}
+
+const arch = process.arch;
+const platform = process.platform;
+const baseFilename = 'libstorj-1.1.0-beta';
+const tag = 'v1.1.0-beta';
+const baseUrl = 'https://github.com/Storj/libstorj/releases/download';
+
+let checksum = null;
+let filename = baseFilename;
+let zip = false;
+
+if (platform === 'linux' && arch === 'arm') {
+  filename += '-linux-armv7.tar.gz';
+  checksum = '4fabbc7fd45d6ca67bcaa0956668451d8d323b4d4c6105b9081b9cbb71c8eaef';
+} else if (platform === 'linux' && arch === 'ia32') {
+  filename += '-linux32.tar.gz';
+  checksum = '1e357a2522c26b11f0ed48a92c6f07567a395bf1924686e1f466f00276d62ac5';
+} else if (platform === 'linux' && arch === 'x64') {
+  filename += '-linux64.tar.gz';
+  checksum = '6bd53c56a9fd43168417263b88add62229bf70f3d3d7dd222550dc99bbc884d5';
+} else if (platform === 'darwin') {
+  filename += '-macos.tar.gz';
+  checksum = 'bbaee4a38566920f69a483da946a1b4173dd4507fb9ba7e2ee1966c0b7e8acca';
+} else if (platform === 'win32' && arch === 'ia32') {
+  zip = true;
+  filename += '-win32.zip';
+  checksum = 'c627f21c9913da6795d4c454e5236f8204567810b9680c5372f76d82a173e3da';
+} else if (platform === 'win32' && arch === 'x64') {
+  zip = true;
+  filename += '-win64.zip';
+  checksum = '1cb5bbc82d077aa975d4debb490ba38a7cc667f32d93042b67dc9c8b6dfb646a';
+} else {
+  stderr.write(`Unable to download libstorj for platform: ${platform} and arch: ${arch}\n`);
+  process.exit(1);
+}
+
+const url = baseUrl + '/' + tag + '/' + filename;;
+const target = path.resolve(basedir, './' + filename);
+const download = `curl --location --fail --connect-timeout 120 --retry 3 -o "${target}" "${url}"`
+const extract = `tar --verbose -xf ${target}`;
+
+stdout.write(`Downloading libstorj from: ${url} to: ${target}\n`);
+execSync(download);
+
+stdout.write(`Extracting target: ${target}\n`);
+execSync(extract);
+
+process.exit(0);

--- a/download.js
+++ b/download.js
@@ -5,6 +5,8 @@ const stdout = process.stdout;
 const stderr = process.stderr;
 const path = require('path');
 const basedir = path.resolve(__dirname);
+const libstorj = require('./package.json').libstorj;
+const releases = libstorj.releases;
 
 let installed = true;
 try {
@@ -20,40 +22,24 @@ if (installed) {
 
 const arch = process.arch;
 const platform = process.platform;
-const baseFilename = 'libstorj-1.1.0-beta';
-const tag = 'v1.1.0-beta';
-const baseUrl = 'https://github.com/Storj/libstorj/releases/download';
+const baseUrl = libstorj.baseUrl;
 
 let checksum = null;
-let filename = baseFilename;
-let zip = false;
+let filename = null;
 
-if (platform === 'linux' && arch === 'arm') {
-  filename += '-linux-armv7.tar.gz';
-  checksum = '4fabbc7fd45d6ca67bcaa0956668451d8d323b4d4c6105b9081b9cbb71c8eaef';
-} else if (platform === 'linux' && arch === 'ia32') {
-  filename += '-linux32.tar.gz';
-  checksum = '1e357a2522c26b11f0ed48a92c6f07567a395bf1924686e1f466f00276d62ac5';
-} else if (platform === 'linux' && arch === 'x64') {
-  filename += '-linux64.tar.gz';
-  checksum = '6bd53c56a9fd43168417263b88add62229bf70f3d3d7dd222550dc99bbc884d5';
-} else if (platform === 'darwin') {
-  filename += '-macos.tar.gz';
-  checksum = 'bbaee4a38566920f69a483da946a1b4173dd4507fb9ba7e2ee1966c0b7e8acca';
-} else if (platform === 'win32' && arch === 'ia32') {
-  zip = true;
-  filename += '-win32.zip';
-  checksum = 'c627f21c9913da6795d4c454e5236f8204567810b9680c5372f76d82a173e3da';
-} else if (platform === 'win32' && arch === 'x64') {
-  zip = true;
-  filename += '-win64.zip';
-  checksum = '1cb5bbc82d077aa975d4debb490ba38a7cc667f32d93042b67dc9c8b6dfb646a';
-} else {
+for (var i = 0; i < releases.length; i++) {
+  if (releases[i].arch === arch && releases[i].platform === platform) {
+    filename = releases[i].filename;
+    checksum = releases[i].checksum;
+  }
+}
+
+if (!filename) {
   stderr.write(`Unable to download libstorj for platform: ${platform} and arch: ${arch}\n`);
   process.exit(1);
 }
 
-const url = baseUrl + '/' + tag + '/' + filename;;
+const url = baseUrl + '/' + filename;
 const target = path.resolve(basedir, './' + filename);
 const download = `curl --location --fail --connect-timeout 120 --retry 3 -o "${target}" "${url}"`
 const extract = `tar --verbose -xf ${target}`;

--- a/download.js
+++ b/download.js
@@ -26,6 +26,7 @@ const baseUrl = libstorj.baseUrl;
 
 let checksum = null;
 let filename = null;
+let sha256sum = (platform === 'darwin') ? 'shasum -a 256' : 'sha256sum';
 
 for (var i = 0; i < releases.length; i++) {
   if (releases[i].arch === arch && releases[i].platform === platform) {
@@ -43,9 +44,19 @@ const url = baseUrl + '/' + filename;
 const target = path.resolve(basedir, './' + filename);
 const download = `curl --location --fail --connect-timeout 120 --retry 3 -o "${target}" "${url}"`
 const extract = `tar --verbose -xf ${target}`;
+const hasher = `${sha256sum} ${target} | awk '{print $1}'`
 
-stdout.write(`Downloading libstorj from: ${url} to: ${target}\n`);
+stdout.write(`Downloading libstorj \n  from: ${url} \n  to: ${target}\n`);
 execSync(download);
+
+const hashbuf = execSync(hasher);
+const hash = hashbuf.toString().trim();
+if (hash === checksum) {
+  stdout.write(`Verified libstorj: \n  file: ${target}\n  hash: ${checksum}\n`);
+} else {
+  stderr.write(`Unable to verify libstorj release: ${target} \n  expect: ${checksum}\n  actual: ${hash}\n`);
+  process.exit(1);
+}
 
 stdout.write(`Extracting target: ${target}\n`);
 execSync(extract);

--- a/download.js
+++ b/download.js
@@ -4,6 +4,7 @@ const { execSync } = require('child_process');
 const stdout = process.stdout;
 const stderr = process.stderr;
 const path = require('path');
+const fs = require('fs');
 const basedir = path.resolve(__dirname);
 const libstorj = require('./package.json').libstorj;
 const releases = libstorj.releases;
@@ -46,8 +47,12 @@ const download = `curl --location --fail --connect-timeout 120 --retry 3 -o "${t
 const extract = `tar --verbose -xf ${target}`;
 const hasher = `${sha256sum} ${target} | awk '{print $1}'`
 
-stdout.write(`Downloading libstorj \n  from: ${url} \n  to: ${target}\n`);
-execSync(download);
+if (fs.existsSync(target)) {
+  stdout.write(`Already downloaded libstorj \n  at: ${target}\n`);
+} else {
+  stdout.write(`Downloading libstorj \n  from: ${url} \n  to: ${target}\n`);
+  execSync(download);
+}
 
 const hashbuf = execSync(hasher);
 const hash = hashbuf.toString().trim();

--- a/package.json
+++ b/package.json
@@ -79,13 +79,13 @@
       {
         "arch": "ia32",
         "platform": "win32",
-        "filename": "libstorj-1.1.0-beta-win32.tar.gz",
+        "filename": "libstorj-1.1.0-beta-win32.zip",
         "checksum": "c627f21c9913da6795d4c454e5236f8204567810b9680c5372f76d82a173e3da"
       },
       {
         "arch": "x64",
         "platform": "win32",
-        "filename": "libstorj-1.1.0-beta-win64.tar.gz",
+        "filename": "libstorj-1.1.0-beta-win64.zip",
         "checksum": "1cb5bbc82d077aa975d4debb490ba38a7cc667f32d93042b67dc9c8b6dfb646a"
       }
     ]

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Node.js bindings to libstorj C library",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/mocha test/**.test.js --recursive"
+    "test": "./node_modules/.bin/mocha test/**.test.js --recursive",
+    "preinstall": "node ./download.js",
+    "install": "node-gyp rebuild"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -47,5 +47,47 @@
     "chai": "^4.0.2",
     "express": "^4.15.3",
     "mocha": "^3.4.2"
+  },
+  "libstorj": {
+    "basePath": "./libstorj-1.1.0-beta",
+    "baseUrl": "https://github.com/Storj/libstorj/releases/download/v1.1.0-beta",
+    "releases": [
+      {
+        "arch": "arm",
+        "platform": "linux",
+        "filename": "libstorj-1.1.0-beta-linux-armv7.tar.gz",
+        "checksum": "4fabbc7fd45d6ca67bcaa0956668451d8d323b4d4c6105b9081b9cbb71c8eaef"
+      },
+      {
+        "arch": "ia32",
+        "platform": "linux",
+        "filename": "libstorj-1.1.0-beta-linux32.tar.gz",
+        "checksum": "1e357a2522c26b11f0ed48a92c6f07567a395bf1924686e1f466f00276d62ac5"
+      },
+      {
+        "arch": "x64",
+        "platform": "linux",
+        "filename": "libstorj-1.1.0-beta-linux64.tar.gz",
+        "checksum": "6bd53c56a9fd43168417263b88add62229bf70f3d3d7dd222550dc99bbc884d5"
+      },
+      {
+        "arch": "x64",
+        "platform": "darwin",
+        "filename": "libstorj-1.1.0-beta-macos.tar.gz",
+        "checksum": "4fabbc7fd45d6ca67bcaa0956668451d8d323b4d4c6105b9081b9cbb71c8eaef"
+      },
+      {
+        "arch": "ia32",
+        "platform": "win32",
+        "filename": "libstorj-1.1.0-beta-win32.tar.gz",
+        "checksum": "c627f21c9913da6795d4c454e5236f8204567810b9680c5372f76d82a173e3da"
+      },
+      {
+        "arch": "x64",
+        "platform": "win32",
+        "filename": "libstorj-1.1.0-beta-win64.tar.gz",
+        "checksum": "1cb5bbc82d077aa975d4debb490ba38a7cc667f32d93042b67dc9c8b6dfb646a"
+      }
+    ]
   }
 }


### PR DESCRIPTION
If libstorj is not already installed on the system, it will download the necessary libstorj release and build bindings linked against it. Currently downloading from https://github.com/Storj/libstorj/releases/tag/v1.1.0-beta