### PR TITLE
Fix macos build

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
-    brew install curl nettle libmicrohttpd libuv
+    HOMEBREW_NO_AUTO_UPDATE=1 brew install curl nettle libmicrohttpd libuv
     git clone https://github.com/Storj/libstorj.git
     cd libstorj
     ./autogen.sh


### PR DESCRIPTION
Fixes `Homebrew must be run under Ruby 2.3!` error